### PR TITLE
use event listener instead of plugin and split code

### DIFF
--- a/src/MessageBundle/LemonmindMessageBundle.php
+++ b/src/MessageBundle/LemonmindMessageBundle.php
@@ -11,6 +11,8 @@ class LemonmindMessageBundle extends AbstractPimcoreBundle
     public function getJsPaths()
     {
         return [
+            '/bundles/lemonmindmessage/js/pimcore/allowedData.js',
+            '/bundles/lemonmindmessage/js/pimcore/getAjax.js',
             '/bundles/lemonmindmessage/js/pimcore/startup.js',
         ];
     }

--- a/src/MessageBundle/Resources/public/js/pimcore/allowedData.js
+++ b/src/MessageBundle/Resources/public/js/pimcore/allowedData.js
@@ -1,0 +1,26 @@
+const allowedData = [
+    {
+        value: 'discord',
+        optionName: 'Discord'
+    },
+    {
+        value: 'googlechat',
+        optionName: 'Google Chat'
+    },
+    {
+        value: 'slack',
+        optionName: 'Slack'
+    },
+    {
+        value: 'telegram',
+        optionName: 'Telegram'
+    },
+    {
+        value: 'email',
+        optionName: 'Email'
+    },
+    {
+        value: 'sms',
+        optionName: 'Sms'
+    },
+]

--- a/src/MessageBundle/Resources/public/js/pimcore/getAjax.js
+++ b/src/MessageBundle/Resources/public/js/pimcore/getAjax.js
@@ -1,0 +1,15 @@
+async function getAjax(url) {
+    return new Ext.Promise(function (resolve, reject) {
+        Ext.Ajax.request({
+            url: url,
+
+            success: function (response) {
+                resolve(response.responseText);
+            },
+
+            failure: function (response) {
+                reject(response.status);
+            }
+        });
+    });
+}

--- a/src/MessageBundle/Resources/public/js/pimcore/startup.js
+++ b/src/MessageBundle/Resources/public/js/pimcore/startup.js
@@ -1,145 +1,100 @@
-pimcore.registerNS("pimcore.plugin.LemonmindMessageBundle");
+document.addEventListener(pimcore.events.postOpenObject, async (e) => {
+    const content = await getAjax('/admin/chatter/class');
+    const responseData = Ext.decode(content)
+    const allowedClasses = responseData.classes
+    const allowedChatters = responseData.allowed_chatters.split(',')
 
-pimcore.plugin.LemonmindMessageBundle = Class.create(pimcore.plugin.admin, {
-    getClassName: function () {
-        return "pimcore.plugin.LemonmindMessageBundle";
-    },
-
-    initialize: function () {
-        pimcore.plugin.broker.registerPlugin(this);
-    },
+    const objectClass = e.detail.object.data.general.o_className;
 
 
-    postOpenObject: function (object, type) {
+    const classToSend = allowedClasses.find(element => {
+        if (element.toLowerCase().includes(objectClass.toLowerCase())) {
+            return true;
+        }
+    });
 
-        Ext.Ajax.request({
-            url: '/admin/chatter/class',
-            success: function (response) {
-                let responseData = Ext.decode(response.responseText);
-                let objectClasses = object.data.general.php.classes;
-                const allowed_chatters = responseData.allowed_chatters.split(',')
+    if (!classToSend) {
+        return
+    }
 
-                function contains(value) {
-                    for (let i = 0; i < responseData.classes.length; i++) {
-                        if (value.includes(responseData.classes[i])) {
-                            return value
+    e.detail.object.toolbar.add({
+        text: t('send-notification'),
+        iconCls: 'pimcore_icon_comments',
+        scale: 'small',
+        handler: function (obj) {
+            let modal = new Ext.Window({
+                title: 'Send notification',
+                modal: true,
+                layout: 'fit',
+                width: 500,
+                height: 250,
+                items: [
+                    new Ext.form.Panel({
+                        layout: 'anchor',
+                        url: '/admin/chatter/send-notification/' + obj.id,
+                        defaults: {
+                            anchor: '100%'
+                        },
+                        items: [{
+                            xtype: 'combo',
+                            name: 'chatter',
+                            fieldLabel: 'Select chatter:',
+                            store: Ext.create('Ext.data.Store', {
+                                fields: ['optionName', 'value'],
+                                data: allowedData.filter(d => allowedChatters.some(e => e === d.value))
+                            }),
+                            emptyText: 'Select one...',
+                            displayField: 'optionName',
+                            valueField: 'value',
+                            allowBlank: false,
+                            margin: '5'
+                        }, {
+                            xtype: 'textareafield',
+                            fieldLabel: 'Additional information (can be blank)',
+                            name: 'additionalInfo',
+                            allowBlank: true,
+                            margin: '5'
+                        },
+                        {
+                            xtype: 'hiddenfield',
+                            name: 'classToSend',
+                            value: classToSend,
                         }
-                    }
-                    return null
-                }
+                        ],
 
-                let classToSend = objectClasses.filter(contains);
-                if (classToSend.length > 0) {
-                    object.toolbar.add({
-                        text: t('send-notification'),
-                        iconCls: 'pimcore_icon_comments',
-                        scale: 'small',
-                        handler: function (obj) {
-                            const allowedData = [
-                                {
-                                    value: 'discord',
-                                    optionName: 'Discord'
-                                },
-                                {
-                                    value: 'googlechat',
-                                    optionName: 'Google Chat'
-                                },
-                                {
-                                    value: 'slack',
-                                    optionName: 'Slack'
-                                },
-                                {
-                                    value: 'telegram',
-                                    optionName: 'Telegram'
-                                },
-                                {
-                                    value: 'email',
-                                    optionName: 'Email'
-                                },
-                                {
-                                    value: 'sms',
-                                    optionName: 'Sms'
-                                },
-                            ]
+                        buttons: [{
+                            text: 'Close',
+                            handler: () => modal.hide(),
+                        }, {
+                            text: 'Send',
+                            formBind: true,
+                            disabled: true,
+                            handler: function () {
+                                let form = this.up('form').getForm();
+                                if (!form.isValid()) {
+                                    pimcore.helpers.showNotification(t("error"), t("Your form is invalid!"), "error");
+                                    return
+                                }
 
-                            let modal = new Ext.Window({
-                                title: 'Send notification',
-                                modal: true,
-                                layout: 'fit',
-                                width: 500,
-                                height: 250,
-                                items: [
-                                    new Ext.form.Panel({
-                                        layout: 'anchor',
-                                        url: '/admin/chatter/send-notification/' + obj.id,
-                                        defaults: {
-                                            anchor: '100%'
-                                        },
-                                        items: [{
-                                            xtype: 'combo',
-                                            name: 'chatter',
-                                            fieldLabel: 'Select chatter:',
-                                            store: Ext.create('Ext.data.Store', {
-                                                fields: ['optionName', 'value'],
-                                                data: allowedData.filter(d => allowed_chatters.some(e => e === d.value))
-                                            }),
-                                            emptyText: 'Select one...',
-                                            displayField: 'optionName',
-                                            valueField: 'value',
-                                            allowBlank: false,
-                                            margin: '5'
-                                        }, {
-                                            xtype: 'textareafield',
-                                            fieldLabel: 'Additional information (can be blank)',
-                                            name: 'additionalInfo',
-                                            allowBlank: true,
-                                            margin: '5'
-                                        },
-                                        {
-                                            xtype: 'hiddenfield',
-                                            name: 'classToSend',
-                                            value: classToSend,
-                                        }
-                                        ],
+                                form.submit({
+                                    success: function (form, action) {
+                                        modal.hide();
+                                        pimcore.helpers.showNotification(t("success"), t("Message sent"), "success");
+                                    },
+                                    failure: function (form, action) {
+                                        modal.hide();
+                                        pimcore.helpers.showNotification(t("error"), t("Error when sending message"), "error");
+                                    },
+                                });
+                            }
+                        }],
+                    })
+                ],
+            });
 
-                                        buttons: [{
-                                            text: 'Close',
-                                            handler: function () {
-                                                modal.hide();
-                                            }
-                                        }, {
-                                            text: 'Send',
-                                            formBind: true,
-                                            disabled: true,
-                                            handler: function () {
-                                                let form = this.up('form').getForm();
-                                                if (form.isValid()) {
-                                                    form.submit({
-                                                        success: function (form, action) {
-                                                            modal.hide();
-                                                            pimcore.helpers.showNotification(t("success"), t("Message sent"), "success");
-                                                        },
-                                                        failure: function (form, action) {
-                                                            modal.hide();
-                                                            pimcore.helpers.showNotification(t("error"), t("Error when sending message"), "error");
-                                                        },
-                                                    });
-                                                }
-                                            }
-                                        }],
-                                    })
-                                ],
-                            });
+            modal.show(this);
 
-                            modal.show(this);
-
-                        }.bind(this, object)
-                    });
-                    pimcore.layout.refresh();
-                }
-            }
-        });
-    },
+        }.bind(this, e.detail.object)
+    });
+    pimcore.layout.refresh();
 });
-
-let LemonmindMessageBundlePlugin = new pimcore.plugin.LemonmindMessageBundle();


### PR DESCRIPTION
According to pimcore 10.5.0 upgrade notes: "plugins are deprecated and will be removed in Pimcore 11. Please use event listener  instead of plugins for JS events.